### PR TITLE
增加双端链表注释 adlist.h / adlist.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ redis仓库链接：https://github.com/redis/redis<br>
 | sds.h | 完成 | 
 | quicklist.h | 完成 | 
 | sds.c | 完成 | 
+| adlist.h | 完成 |
+| adlist.c | 完成 |
 </p>
 尚未有中文注释的文件不会出现在表格中。<br>
 更新日期：2022/5/2

--- a/src/adlist.c
+++ b/src/adlist.c
@@ -39,12 +39,17 @@
  * listSetFreeMethod.
  *
  * On error, NULL is returned. Otherwise the pointer to the new list. */
+
+/* 创建一个新链表，链表可以使用 listRelease 进行释放，如果链表节点有自己的私有值 void *value，
+ * 需要设置 listSetFreeMethod 来定义自己的释放函数，用于释放链表节点空间。*/
 list *listCreate(void)
 {
     struct list *list;
 
+    /* 申请链表空间 */
     if ((list = zmalloc(sizeof(*list))) == NULL)
         return NULL;
+    /* 初始化链表 */
     list->head = list->tail = NULL;
     list->len = 0;
     list->dup = NULL;
@@ -54,19 +59,27 @@ list *listCreate(void)
 }
 
 /* Remove all the elements from the list without destroying the list itself. */
+/* 清空一个链表，即清空回收所有链表节点，这个不会回收链表本身，时间复杂度 O(N) */
 void listEmpty(list *list)
 {
     unsigned long len;
     listNode *current, *next;
 
+    /* 当前指针先指向头节点 */
     current = list->head;
+    /* O(1) 时间复杂度获取链表长度（节点数量） */
     len = list->len;
     while(len--) {
+        /* 先记录下一跳节点 */
         next = current->next;
+        /* 如果链表有定义 free 函数，调用它来释放节点的 value */
         if (list->free) list->free(current->value);
+        /* 释放链表节点 */
         zfree(current);
+        /* 当前指针指向下一跳节点，处理下一个节点 */
         current = next;
     }
+    /* 清空完链表后，将头尾节点指针置空，将链表长度置 0 */
     list->head = list->tail = NULL;
     list->len = 0;
 }
@@ -74,6 +87,7 @@ void listEmpty(list *list)
 /* Free the whole list.
  *
  * This function can't fail. */
+/* 释放一个链表，通过调用 listEmpty 清空链表节点，然后 zfree 链表空间 */
 void listRelease(list *list)
 {
     listEmpty(list);
@@ -86,22 +100,33 @@ void listRelease(list *list)
  * On error, NULL is returned and no operation is performed (i.e. the
  * list remains unaltered).
  * On success the 'list' pointer you pass to the function is returned. */
+
+/* 在链表头部插入节点（头插法），时间复杂度 O(1)
+ * 例如 B->C->D 插入 A 节点变成 A->B->C->D */
 list *listAddNodeHead(list *list, void *value)
 {
     listNode *node;
 
+    /* 分配节点空间 */
     if ((node = zmalloc(sizeof(*node))) == NULL)
         return NULL;
+    /* 设置节点 value */
     node->value = value;
     if (list->len == 0) {
+        /* 链表长度为 0 说明是一个空链表，插入后只有一个节点，
+         * 新节点同时也是链表的头尾节点，前驱节点和后继节点都为空。 */
         list->head = list->tail = node;
         node->prev = node->next = NULL;
     } else {
+        /* 链表不为空，插入的节点将作为链表的新头节点，
+         * 新节点作为新头节点前驱节点为空，后继节点为链表原先的头节点，
+         * 链表原先的头节点的前驱节点为新节点。*/
         node->prev = NULL;
         node->next = list->head;
         list->head->prev = node;
         list->head = node;
     }
+    /* 维护链表长度 */
     list->len++;
     return list;
 }
@@ -112,51 +137,72 @@ list *listAddNodeHead(list *list, void *value)
  * On error, NULL is returned and no operation is performed (i.e. the
  * list remains unaltered).
  * On success the 'list' pointer you pass to the function is returned. */
+/* 在链表尾部插入节点（尾插法），时间复杂度 O(1)
+ * 例如 A->B->C 插入 D 节点变成 A->B->C->D */
 list *listAddNodeTail(list *list, void *value)
 {
     listNode *node;
 
+    /* 分配节点空间 */
     if ((node = zmalloc(sizeof(*node))) == NULL)
         return NULL;
+    /* 设置节点 value */
     node->value = value;
     if (list->len == 0) {
+        /* 链表长度为 0 说明是一个空链表，插入后只有一个节点，
+         * 新节点同时也是链表的头尾节点，前驱节点和后继节点都为空。 */
         list->head = list->tail = node;
         node->prev = node->next = NULL;
     } else {
+        /* 链表不为空，插入的节点将作为链表的新尾节点，
+         * 新节点作为新尾节点后继节点为空，前驱节点为链表原先的尾节点，
+         * 链表原先的尾节点的后继节点为新节点。*/
         node->prev = list->tail;
         node->next = NULL;
         list->tail->next = node;
         list->tail = node;
     }
+    /* 维护链表长度 */
     list->len++;
     return list;
 }
 
+/* 在 old_node 的前面或者后面插入一个新节点，时间复杂度 O(1) */
 list *listInsertNode(list *list, listNode *old_node, void *value, int after) {
     listNode *node;
 
+    /* 分配节点空间 */
     if ((node = zmalloc(sizeof(*node))) == NULL)
         return NULL;
+    /* 设置节点 value */
     node->value = value;
     if (after) {
+        /* 在 old_node 后面插入新节点
+         * 新节点的前驱节点为 old_node，新节点的后继节点为 old_node 的后继节点 */
         node->prev = old_node;
         node->next = old_node->next;
+        /* 如果 old_node 是链表尾节点，在它后面插入新节点，新节点将变成链表新尾节点 */
         if (list->tail == old_node) {
             list->tail = node;
         }
     } else {
+        /* 在 old_node 前面插入新节点
+         * 新节点的后继节点为 old_node，新节点的前驱节点为 old_node 的前驱节点 */
         node->next = old_node;
         node->prev = old_node->prev;
+        /* 如果 old_node 是链表头节点，在它前面插入新节点，新节点将变成链表新头节点 */
         if (list->head == old_node) {
             list->head = node;
         }
     }
+    /* 维护好前后节点的指针 */
     if (node->prev != NULL) {
         node->prev->next = node;
     }
     if (node->next != NULL) {
         node->next->prev = node;
     }
+    /* 维护链表长度 */
     list->len++;
     return list;
 }
@@ -165,18 +211,26 @@ list *listInsertNode(list *list, listNode *old_node, void *value, int after) {
  * It's up to the caller to free the private value of the node.
  *
  * This function can't fail. */
+/* 在链表中删除指定节点，时间复杂度 O(1) */
 void listDelNode(list *list, listNode *node)
 {
+    /* 如果节点有前驱节点，前驱节点的后继节点需要变更为删除节点的后继节点
+     * 如果没有前驱节点，说明是链表头节点，链表新头节点变成删除节点的后继节点 */
     if (node->prev)
         node->prev->next = node->next;
     else
         list->head = node->next;
+    /* 如果节点有后继节点，后继节点的前驱节点需要变更为删除节点的前驱节点
+     * 如果没有后继节点，说明是链表尾节点，链表新尾节点变成删除节点的前驱节点 */
     if (node->next)
         node->next->prev = node->prev;
     else
         list->tail = node->prev;
+    /* 如果链表有定义 free 函数，调用它释放 node->value */
     if (list->free) list->free(node->value);
+    /* 释放删除节点空间 */
     zfree(node);
+    /* 维护链表长度 */
     list->len--;
 }
 
@@ -184,20 +238,25 @@ void listDelNode(list *list, listNode *node)
  * call to listNext() will return the next element of the list.
  *
  * This function can't fail. */
+/* 根据遍历方向获得一个 iterator，可以看到是根据方向来决定从头节点还是尾节点开始
+ * 调用方通过调用 listNext 来获取下一个节点 */
 listIter *listGetIterator(list *list, int direction)
 {
     listIter *iter;
 
     if ((iter = zmalloc(sizeof(*iter))) == NULL) return NULL;
+    /* 根据方向设置 iter->next 为头节点或者尾节点 */
     if (direction == AL_START_HEAD)
         iter->next = list->head;
     else
         iter->next = list->tail;
+    /* 设置方向 */
     iter->direction = direction;
     return iter;
 }
 
 /* Release the iterator memory */
+/* 释放 listGetIterator 获取到的 iterator */
 void listReleaseIterator(listIter *iter) {
     zfree(iter);
 }
@@ -227,10 +286,15 @@ void listRewindTail(list *list, listIter *li) {
  * }
  *
  * */
+/* 根据迭代器从链表中获取下一个节点，时间复杂度 O(1)
+ * 获取的节点可以通过 listDelNode 进行删除 */
 listNode *listNext(listIter *iter)
 {
     listNode *current = iter->next;
 
+    /* current 不为空，根据方向获取链表的下一个节点
+     * HEAD: 通过 node->next 获取后继节点
+     * TAIL: 通过 node->prev 获取前驱节点 */
     if (current != NULL) {
         if (iter->direction == AL_START_HEAD)
             iter->next = current->next;
@@ -248,6 +312,7 @@ listNode *listNext(listIter *iter)
  * the original node is used as value of the copied node.
  *
  * The original list both on success or error is never modified. */
+/* 复制一个链表，返回新链表的指针，时间复杂度 O(N) */
 list *listDup(list *orig)
 {
     list *copy;
@@ -256,31 +321,39 @@ list *listDup(list *orig)
 
     if ((copy = listCreate()) == NULL)
         return NULL;
+    /* 初始化相关的复制/释放/比较函数 */
     copy->dup = orig->dup;
     copy->free = orig->free;
     copy->match = orig->match;
+    /* 从链表头开始遍历，复制节点 */
     listRewind(orig, &iter);
     while((node = listNext(&iter)) != NULL) {
         void *value;
 
         if (copy->dup) {
+            /* 如果链表有定义自己的复制函数，调用它复制链表节点 */
             value = copy->dup(node->value);
             if (value == NULL) {
+                /* 如果节点复制失败，释放新链表并返回 NULL */
                 listRelease(copy);
                 return NULL;
             }
         } else {
+            /* 否则单纯进行 value 的引用复制 */
             value = node->value;
         }
-        
+
+        /* 将节点插入到新链表的尾部 */
         if (listAddNodeTail(copy, value) == NULL) {
             /* Free value if dup succeed but listAddNodeTail failed. */
+            /* 如果添加节点失败并且链表有定义自己的 free 函数，通过它释放 value */
             if (copy->free) copy->free(value);
-
+            /* 释放新链表并且返回 NULL */
             listRelease(copy);
             return NULL;
         }
     }
+    /* 返回复制的新链表 */
     return copy;
 }
 
@@ -293,18 +366,23 @@ list *listDup(list *orig)
  * On success the first matching node pointer is returned
  * (search starts from head). If no matching node exists
  * NULL is returned. */
+
+/* 根据节点 key 在链表中搜索对应的节点，时间复杂度 O(N) */
 listNode *listSearchKey(list *list, void *key)
 {
     listIter iter;
     listNode *node;
 
+    /* 从链表头开始遍历 */
     listRewind(list, &iter);
     while((node = listNext(&iter)) != NULL) {
         if (list->match) {
+            /* 如果链表有定义自己的 match 函数，调用它来进行比较 */
             if (list->match(node->value, key)) {
                 return node;
             }
         } else {
+            /* 否则就单纯比较 key 和 node->value */
             if (key == node->value) {
                 return node;
             }
@@ -318,14 +396,20 @@ listNode *listSearchKey(list *list, void *key)
  * and so on. Negative integers are used in order to count
  * from the tail, -1 is the last element, -2 the penultimate
  * and so on. If the index is out of range NULL is returned. */
+/* 通过下标返回链表节点，时间复杂度 O(N)
+ * 支持传入负下标，例如 -1 为最后一个节点，-2 为倒数第二个节点 */
 listNode *listIndex(list *list, long index) {
     listNode *n;
 
     if (index < 0) {
+        /* 支持传入负下标，从尾节点开始向前遍历
+         * 例如获取倒数第二个节点，index = -2, (-index)-1 = 1
+         * 从尾节点开始跳过一个节点就到达目标节点了 */
         index = (-index)-1;
         n = list->tail;
         while(index-- && n) n = n->prev;
     } else {
+        /* 正下标，从链表头开始向后遍历 */
         n = list->head;
         while(index-- && n) n = n->next;
     }
@@ -333,21 +417,33 @@ listNode *listIndex(list *list, long index) {
 }
 
 /* Rotate the list removing the tail node and inserting it to the head. */
+/* 将尾节点移动到链表头部，时间复杂度 O(1) */
 void listRotateTailToHead(list *list) {
     if (listLength(list) <= 1) return;
 
     /* Detach current tail */
+    /* 将尾节点从链表中摘出来，维护链表指针
+     * 链表新尾节点为 tail 的前驱节点
+     * 链表新尾节点的后继节点为空 */
     listNode *tail = list->tail;
     list->tail = tail->prev;
     list->tail->next = NULL;
+
     /* Move it as head */
+    /* 将链表老尾节点移动到链表头部，此时它为新头节点
+     * 链表老头节点的前驱节点为新头节点
+     * 链表新头节点的前驱节点为空，后继节点为原先的老头节点 */
     list->head->prev = tail;
     tail->prev = NULL;
     tail->next = list->head;
+
+    /* 链表的新头节点为老尾节点 */
     list->head = tail;
 }
 
 /* Rotate the list removing the head node and inserting it to the tail. */
+/* 将头节点移动到链表尾部，时间复杂度 O(1)
+ * 这个处理过程同上，维护好相关指针 */
 void listRotateHeadToTail(list *list) {
     if (listLength(list) <= 1) return;
 
@@ -364,20 +460,28 @@ void listRotateHeadToTail(list *list) {
 
 /* Add all the elements of the list 'o' at the end of the
  * list 'l'. The list 'other' remains empty but otherwise valid. */
+/* 连接两个链表，将 o 链表连到 l 链表的尾部 */
 void listJoin(list *l, list *o) {
+    /* 如果 o 链表为空直接返回，不处理 */
     if (o->len == 0) return;
 
+    /* o 链表头节点的前驱节点为 l 链表的尾节点 */
     o->head->prev = l->tail;
 
+    /* 如果 l 链表不为空，l 链表尾节点的后继节点为 o 链表的头节点
+     * 如果 l 链表为空，l 链表的头节点直接就有 o 链表的头节点 */
     if (l->tail)
         l->tail->next = o->head;
     else
         l->head = o->head;
 
+    /* 连接 o 链表，此时 l 链表的尾节点直接置为 o 链表的尾节点 */
     l->tail = o->tail;
+    /* l 链表的长度直接再加上 o 链表的长度 */
     l->len += o->len;
 
     /* Setup other as an empty list. */
+    /* 将 o 链表的 head / tail / len 元数据置空 */
     o->head = o->tail = NULL;
     o->len = 0;
 }

--- a/src/adlist.h
+++ b/src/adlist.h
@@ -33,27 +33,43 @@
 
 /* Node, List, and Iterator are the only data structures used currently. */
 
+/* 双端链表节点 */
 typedef struct listNode {
+    /* 指向前驱节点的指针 */
     struct listNode *prev;
+    /* 指向后继节点的指针 */
     struct listNode *next;
+    /* void * 指针，指向具体的元素，节点可以是任意类型 */
     void *value;
 } listNode;
 
+/* 双端链表迭代器 */
 typedef struct listIter {
+    /* 指向遍历的下一个节点的指针 */
     listNode *next;
+    /* 遍历的方向：从表头遍历还是从表尾遍历 */
     int direction;
 } listIter;
 
+/* 双端链表
+ * 有记录头尾两节点，支持从链表头部或者尾部进行遍历，是早期列表键 PUSH/POP 实现高效的关键
+ * 每个链表节点有记录前驱节点和后继节点的指针，可以使得列表键支持往后或者往前进行遍历
+ * 有额外用 len 存储链表长度，O(1) 的时间复杂度获取节点个数，是 LLEN 命令高效的关键 */
 typedef struct list {
+    /* 指向链表头节点的指针，支持从表头开始遍历 */
     listNode *head;
+    /* 指向链表尾节点的指针，支持从表尾开始遍历 */
     listNode *tail;
+    /* 各种类型的链表可以定义自己的复制函数 / 释放函数 / 比较函数 */
     void *(*dup)(void *ptr);
     void (*free)(void *ptr);
     int (*match)(void *ptr, void *key);
+    /* 链表长度，即链表节点数量，O(1) 时间复杂度获取 */
     unsigned long len;
 } list;
 
 /* Functions implemented as macros */
+/* 一些链表操作的辅助方法 */
 #define listLength(l) ((l)->len)
 #define listFirst(l) ((l)->head)
 #define listLast(l) ((l)->tail)
@@ -61,10 +77,12 @@ typedef struct list {
 #define listNextNode(n) ((n)->next)
 #define listNodeValue(n) ((n)->value)
 
+/* 设置链表的相关函数指针 */
 #define listSetDupMethod(l,m) ((l)->dup = (m))
 #define listSetFreeMethod(l,m) ((l)->free = (m))
 #define listSetMatchMethod(l,m) ((l)->match = (m))
 
+/* 获取链表的相关函数指针 */
 #define listGetDupMethod(l) ((l)->dup)
 #define listGetFreeMethod(l) ((l)->free)
 #define listGetMatchMethod(l) ((l)->match)
@@ -90,6 +108,7 @@ void listRotateHeadToTail(list *list);
 void listJoin(list *l, list *o);
 
 /* Directions for iterators */
+/* 在遍历迭代器中使用的方向 HEAD / TAIL */
 #define AL_START_HEAD 0
 #define AL_START_TAIL 1
 


### PR DESCRIPTION
双端链表的实现虽然简单，但它是很基础的一种数据结构，需要掌握。

在早期 3.2 版本之前，列表键底层实现为 双端链表或者压缩列表 ziplist，
3.2 版本之后，使用了 quicklist 快速列表来作为链表键的底层实现，
quicklist 实际上就是双端链表加压缩列表实现的一种数据结构，充分利用两者的优势。

在 7.0 版本后，使用 listpack 紧凑列表来代替压缩列表了。