### PR TITLE
增加和完善一些 sds/ziplist 注释

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ redis 仓库链接：https://github.com/redis/redis<br>
 | [sentinel.c](https://github.com/CN-annotation-team/redis7.0-chinese-annotated/blob/7.0-cn-annotated/src/sentinel.c) | sentinel 哨兵机制的具体实现 | 低于一半 |
 </p>
 尚未有中文注释的文件不会出现在表格中。<br>
-更新日期：2022/6/7
+更新日期：2022/6/8
 
 
 ## 关于提交 PR 的方法：

--- a/src/sds.c
+++ b/src/sds.c
@@ -235,7 +235,7 @@ sds _sdsMakeRoomFor(sds s, size_t addlen, int greedy) {
     int hdrlen;
     size_t usable;
 
-    /* 剩余空间大于等于新增空间，无需扩容，直接返回源字符串 空间足够时的优化 */
+    /* 剩余空间大于等于新增空间，无需扩容，直接返回原字符串 - 空间足够时的优化 */
     if (avail >= addlen) return s;
 
     len = sdslen(s);

--- a/src/sds.c
+++ b/src/sds.c
@@ -97,7 +97,7 @@ static inline size_t sdsTypeMaxSize(char type) {
  * mystring = sdsnewlen("abc",3);
  *
  * 您可以使用 printf() 打印字符串, 因为字符串末尾有一个隐式的 \0.
- * 不过, sds字符串是二进制安全的, 中间可以包含 \0 字符, 因为长度存储在 sds 头部信息中 */
+ * 不过, sds 字符串本身是二进制安全的, 中间可以存储 \0, 因为字符串的实际长度是存储在 sds header 中 */
 sds _sdsnewlen(const void *init, size_t initlen, int trymalloc) {
     void *sh;
     sds s;

--- a/src/sds.c
+++ b/src/sds.c
@@ -243,7 +243,7 @@ sds _sdsMakeRoomFor(sds s, size_t addlen, int greedy) {
     reqlen = newlen = (len+addlen);
     assert(newlen > len);   /* 处理 size_t 溢出 */
     if (greedy == 1) {
-        /* 新增后长度小于 1MB ，则按新长度的两倍扩容 */
+        /* 新增后长度小于 1MB ，则按新长度的两倍扩容（成倍扩容） */
         if (newlen < SDS_MAX_PREALLOC)
             newlen *= 2;
         else

--- a/src/sds.c
+++ b/src/sds.c
@@ -97,7 +97,7 @@ static inline size_t sdsTypeMaxSize(char type) {
  * mystring = sdsnewlen("abc",3);
  *
  * 您可以使用 printf() 打印字符串, 因为字符串末尾有一个隐式的 \0.
- * 不过, 字符串是二进制安全的, 中间可以包含 \0 字符, 因为长度存储在 sds 头部信息中 */
+ * 不过, sds字符串是二进制安全的, 中间可以包含 \0 字符, 因为长度存储在 sds 头部信息中 */
 sds _sdsnewlen(const void *init, size_t initlen, int trymalloc) {
     void *sh;
     sds s;
@@ -218,7 +218,7 @@ void sdsclear(sds s) {
     s[0] = '\0';
 }
 
-/* 扩大 sds 字符串末端的空闲空间,
+/* 自动扩容机制 - 扩大 sds 字符串末端的空闲空间,
  * 这样, 调用者就可以确定在调用这个函数之后,
  * 字符串末尾的 addlen 字节是可覆写的, 然后再加上 nul 项的一个字节.
  * 如果已经有足够的空闲空间, 这个函数会返回且不做任何动作,
@@ -235,7 +235,7 @@ sds _sdsMakeRoomFor(sds s, size_t addlen, int greedy) {
     int hdrlen;
     size_t usable;
 
-    /* 空间足够时的优化. */
+    /* 剩余空间大于等于新增空间，无需扩容，直接返回源字符串 空间足够时的优化 */
     if (avail >= addlen) return s;
 
     len = sdslen(s);
@@ -243,9 +243,11 @@ sds _sdsMakeRoomFor(sds s, size_t addlen, int greedy) {
     reqlen = newlen = (len+addlen);
     assert(newlen > len);   /* 处理 size_t 溢出 */
     if (greedy == 1) {
+        /* 新增后长度小于 1MB ，则按新长度的两倍扩容 */
         if (newlen < SDS_MAX_PREALLOC)
             newlen *= 2;
         else
+            /* 新增后长度大于 1MB ，则按新长度加上 1MB 扩容 */
             newlen += SDS_MAX_PREALLOC;
     }
 
@@ -289,7 +291,7 @@ sds sdsMakeRoomForNonGreedy(sds s, size_t addlen) {
     return _sdsMakeRoomFor(s, addlen, 0);
 }
 
-/* 再分配 sds 字符串, 分配目的是移出未使用的尾部空闲空间.
+/* 再分配 sds 字符串, 分配目的是移出未使用的尾部空闲空间 真正释放SDS未使用空间.
  * 所包含的字符串并没有被改变, 但是下一次拼接时将会需要再分配.
  *
  * 在这次调用后, 传入的字符串将会失效,
@@ -796,6 +798,7 @@ sds sdstrim(sds s, const char *cset) {
     len = (ep-sp)+1;
     if (s != sp) memmove(s, sp, len);
     s[len] = '\0';
+    // 仅仅更新了len 惰性空间释放 真正释放可以看函数sdsRemoveFreeSpace
     sdssetlen(s,len);
     return s;
 }

--- a/src/sds.c
+++ b/src/sds.c
@@ -291,7 +291,7 @@ sds sdsMakeRoomForNonGreedy(sds s, size_t addlen) {
     return _sdsMakeRoomFor(s, addlen, 0);
 }
 
-/* 再分配 sds 字符串, 分配目的是移出未使用的尾部空闲空间 真正释放SDS未使用空间.
+/* 再分配 sds 字符串, 分配目的是移除未使用的 buf 尾部空闲空间，真正释放 SDS 未使用空间.
  * 所包含的字符串并没有被改变, 但是下一次拼接时将会需要再分配.
  *
  * 在这次调用后, 传入的字符串将会失效,

--- a/src/sds.c
+++ b/src/sds.c
@@ -798,7 +798,7 @@ sds sdstrim(sds s, const char *cset) {
     len = (ep-sp)+1;
     if (s != sp) memmove(s, sp, len);
     s[len] = '\0';
-    // 仅仅更新了len 惰性空间释放 真正释放可以看函数sdsRemoveFreeSpace
+    /* 仅仅更新了 len 而没进行实际的内存释放（惰性空间释放），真正释放可以看函数 sdsRemoveFreeSpace */
     sdssetlen(s,len);
     return s;
 }

--- a/src/sds.h
+++ b/src/sds.h
@@ -42,11 +42,10 @@ extern const char *SDS_NOINIT;
 
 typedef char *sds; /* Simple Dynamic String 简单动态字符串 */
 
-/* __packed__ 取消结构在编译过程中的优化对齐，按照实际占用字节数进行对齐
- * SDS 数据结构定义 <len><alloc><flags><buf>
- * 特性1 指针是直接指向buf 使得可以直接使用 C 语言string.h库中的函数
- * 特性2 并且前进一位就能直接获取flags。从而快速拿到类型
- * redis 为了上述两个特性 牺牲了对齐填充
+/* __packed__ 取消结构在编译过程中的优化对齐，按照实际占用字节数进行内存分配
+ * SDS 数据结构定义：<len><alloc><flags><buf>
+ * 特性1：sds 指针是直接指向 buf 字节数组，使得 SDS 可以直接使用 C 语言 string.h 库中的函数
+ * 特性2：并且根据 buf 前进一位就能直接获取 flags，从而快速拿到类型，例如 `unsigned char flags = s[-1]`
  * */
 
 /* 注意: sdshdr5 从未被使用, 我们仅访问 flags 字节.

--- a/src/sds.h
+++ b/src/sds.h
@@ -42,6 +42,13 @@ extern const char *SDS_NOINIT;
 
 typedef char *sds; /* Simple Dynamic String 简单动态字符串 */
 
+/* __packed__ 取消结构在编译过程中的优化对齐，按照实际占用字节数进行对齐
+ * SDS 数据结构定义 <len><alloc><flags><buf>
+ * 特性1 指针是直接指向buf 使得可以直接使用 C 语言string.h库中的函数
+ * 特性2 并且前进一位就能直接获取flags。从而快速拿到类型
+ * redis 为了上述两个特性 牺牲了对齐填充
+ * */
+
 /* 注意: sdshdr5 从未被使用, 我们仅访问 flags 字节.
  * 虽说如此, 这里还是记录一下 SDS5 字符串的空间布局. */
 struct __attribute__ ((__packed__)) sdshdr5 {
@@ -88,7 +95,7 @@ struct __attribute__ ((__packed__)) sdshdr64 {
 
 /* 获取 SDS 的长度 */
 static inline size_t sdslen(const sds s) {
-    unsigned char flags = s[-1]; /* 取出 s 的前一个字节, 用作类型判断 (仔细观测sds数据结构的定义) */
+    unsigned char flags = s[-1]; /* 根据sds数据结构的定义，sds的指针是指向buf,前一个字节就是flags，用作类型判断 */
     switch(flags&SDS_TYPE_MASK) { /* & 0b0111 取出3位低有效位中的类型 */
         case SDS_TYPE_5:
             return SDS_TYPE_5_LEN(flags);

--- a/src/sds.h
+++ b/src/sds.h
@@ -94,7 +94,7 @@ struct __attribute__ ((__packed__)) sdshdr64 {
 
 /* 获取 SDS 的长度 */
 static inline size_t sdslen(const sds s) {
-    unsigned char flags = s[-1]; /* 根据sds数据结构的定义，sds的指针是指向buf,前一个字节就是flags，用作类型判断 */
+    unsigned char flags = s[-1]; /* 根据 sds 数据结构的定义，sds 的指针是指向 buf,前一个字节就是 flags，用作类型判断 */
     switch(flags&SDS_TYPE_MASK) { /* & 0b0111 取出3位低有效位中的类型 */
         case SDS_TYPE_5:
             return SDS_TYPE_5_LEN(flags);

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -870,7 +870,7 @@ unsigned char *ziplistNew(void) {
     unsigned char *zl = zmalloc(bytes);
 
     /* zlbytes: 将 ziplist 总字节数写进内存
-     * 既为ziplist的起始地址，又负责记录ziplist的字节长度，zlbytes固定4字节，也就代表了一个ziplist最长为(2^32)-1字节*/
+     * zl 既为 ziplist 的起始地址，其中值又负责记录 ziplist 的总字节长度，zlbytes 编码存储固定 4 字节，也就代表了一个 ziplist 总字节最大为为 (2^32)-1 字节*/
     ZIPLIST_BYTES(zl) = intrev32ifbe(bytes);
     /* zltail: 将到尾节点的偏移量写进内存，因为是刚初始化的 ziplist，
      * 偏移量其实就是 HEADER_SIZE 值，此时它刚好指向 zlend，因此能够以 O(1) 时间复杂度快速在尾部进行 push 或 pop 操作 */

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -864,7 +864,7 @@ static inline void zipAssertValidEntry(unsigned char* zl, size_t zlbytes, unsign
 unsigned char *ziplistNew(void) {
     /* ziplist_header，两个 uint32_t + 一个 uint16_t，即 zlbytes(4) + zltail(4) + zllen(2) = 10 bytes
      * ziplist_end，一个 uint8_t 即 zlend 为 1 byte
-     * 初始化好header与end共11字节 */
+     * 初始化好 header 跟 end 共 11 字节 */
     unsigned int bytes = ZIPLIST_HEADER_SIZE+ZIPLIST_END_SIZE;
     /* 给 ziplist 分配内存空间 */
     unsigned char *zl = zmalloc(bytes);

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1340,7 +1340,7 @@ unsigned char *__ziplistDelete(unsigned char *zl, unsigned char *p, unsigned int
  *
  * 插入一个新的 entry 需要更新:
  *     插入 entry 后面节点的 prevlen 字段 (插入后需要维护后一个节点的元数据信息)
- *     维护 ziplist 首部的一些字段 => zlbytes,zltail,zllen */
+ *     维护 ziplist 首部的一些字段（zlbytes, zltail, zllen） */
 unsigned char *__ziplistInsert(unsigned char *zl, unsigned char *p, unsigned char *s, unsigned int slen) {
     /* curlen: 当前 ziplist 的完整字节长度
        reqlen: 新节点插入需要的最终字节长度，即新节点的长度（请求长度）

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -873,7 +873,7 @@ unsigned char *ziplistNew(void) {
      * 既为ziplist的起始地址，又负责记录ziplist的字节长度，zlbytes固定4字节，也就代表了一个ziplist最长为(2^32)-1字节*/
     ZIPLIST_BYTES(zl) = intrev32ifbe(bytes);
     /* zltail: 将到尾节点的偏移量写进内存，因为是刚初始化的 ziplist，
-     * 偏移量其实就是 HEADER_SIZE 值，此时它刚好指向 zlend，能够快速地执行push或pop操作 */
+     * 偏移量其实就是 HEADER_SIZE 值，此时它刚好指向 zlend，因此能够以 O(1) 时间复杂度快速在尾部进行 push 或 pop 操作 */
     ZIPLIST_TAIL_OFFSET(zl) = intrev32ifbe(ZIPLIST_HEADER_SIZE);
     /* zllen: 将 ziplist 节点数量写进内存，初始化是 0 */
     ZIPLIST_LENGTH(zl) = 0;


### PR DESCRIPTION
1. 补充 sds  使用__packed__ 的原因
2. 其他的一些注释补充
3. 删除 src/ziplist.c 1340 “插入 entry 的 prevlen 字段 (根据前一个 entry 计算赋值)” 的注释。
这里说辞感觉有点问题，读取了前一个 entry节点的总字节作为插入entry节点 的 prevlen ，
不应该说成插入一个新的 entry 需要更新的内容，本身就是插入结点应该插入的内容之一。