### PR TITLE
增加 localtime.c 和 mt19937-64.h mt19937-64.c ​注释

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 default: all
 
+# $(MAKE) $@：递归调用子目录的 Makefile，并传递当前目标名
 .DEFAULT:
 	cd src && $(MAKE) $@
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,18 @@ redis 仓库链接：https://github.com/redis/redis<br>
 | [geohash_helper.c](https://github.com/CN-annotation-team/redis7.0-chinese-annotated/blob/7.0-cn-annotated/src/geohash_helper.c) | geo 功能  | 完成 |
 | [rax.h](https://github.com/CN-annotation-team/redis7.0-chinese-annotated/blob/7.0-cn-annotated/src/rax.h) | Redis 压缩前缀树定义 | 完成 |
 | [rax.c](https://github.com/CN-annotation-team/redis7.0-chinese-annotated/blob/7.0-cn-annotated/src/rax.c) | Redis 压缩前缀树实现 | 过半 |
+| [localtime.c ](https://github.com/CN-annotation-team/redis7.0-chinese-annotated/blob/7.0-cn-annotated/src/localtime.c) | 实现一个无锁的本地时间转换函数 | 完成 |
+| [mt19937-64.h ​](https://github.com/CN-annotation-team/redis7.0-chinese-annotated/blob/7.0-cn-annotated/src/mt19937-64.h​) | 基于64位梅森旋转算法生成高质量伪随机数获取接口声明 | 完成 |
+| [mt19937-64.c ​](https://github.com/CN-annotation-team/redis7.0-chinese-annotated/blob/7.0-cn-annotated/src/mt19937-64.c​) | 通过64位梅森旋转算法生成高质量伪随机数实现 | 完成 |
+| [crc16.c ​](https://github.com/CN-annotation-team/redis7.0-chinese-annotated/blob/7.0-cn-annotated/src/crc16.c​) | 生成 CRC16（2 字节）校验码实现 | 完成 |
+| [crc16_slottable.h ​](https://github.com/CN-annotation-team/redis7.0-chinese-annotated/blob/7.0-cn-annotated/src/crc16_slottable.h​) | crc16 校验码到 Redis 集群槽位（slot）的映射关系 | 完成 |
+| [crc64.h ​](https://github.com/CN-annotation-team/redis7.0-chinese-annotated/blob/7.0-cn-annotated/src/crc64.h​) | 生成 CRC64（8 字节）校验码，暴露接口声明 | 完成 |
+| [crc64.c ​](https://github.com/CN-annotation-team/redis7.0-chinese-annotated/blob/7.0-cn-annotated/src/crc64.c​) | 生成 CRC64（8 字节）校验码的相关实现，5.0 版本时仍是传统的逐字节查表法（此时只有该文件，实现和 CRC16 一致），6.0 后引入 ​CRCSpeed 库，基于 ​slicing-by-8 技术 | 完成 |
+| [crcspeed.h ​](https://github.com/CN-annotation-team/redis7.0-chinese-annotated/blob/7.0-cn-annotated/src/crcspeed.h​) | 基于 ​slicing-by-8 技术，加速计算 CRC 值，相关获取接口声明 | 完成 |
+| [crcspeed.c ​](https://github.com/CN-annotation-team/redis7.0-chinese-annotated/blob/7.0-cn-annotated/src/crcspeed.c​) | 基于 ​slicing-by-8 技术，及动态生成查表，相关接口实现 | 完成 |
 </p>
 尚未有中文注释的文件不会出现在表格中。<br>
-更新日期：2024/08/24
+更新日期：2025/03/24
 
 
 ## 关于提交 PR 的方法：

--- a/src/crc16.c
+++ b/src/crc16.c
@@ -1,4 +1,4 @@
-#include "server.h"
+#include "server.h"         // crc16声明所在头文件
 
 /*
  * Copyright 2001-2010 Georges Menie (www.menie.org)

--- a/src/crc16.c
+++ b/src/crc16.c
@@ -44,6 +44,12 @@
  * Output for "123456789"     : 31C3
  */
 
+/* 该文件实现了一个 ​CRC16 校验算法，用于计算输入数据的 ​CRC16 值。
+* CRC（循环冗余校验）是一种常用的数据校验方法，用于检测数据传输或存储过程中是否发生错误。
+* 该实现基于 ​XMODEM CRC16 算法，使用预计算的 CRC 表来加速计算
+*/
+
+/* 预计算的 CRC16 表：每个值对应一个字节（0-255）的 CRC16 计算结果 */
 static const uint16_t crc16tab[256]= {
     0x0000,0x1021,0x2042,0x3063,0x4084,0x50a5,0x60c6,0x70e7,
     0x8108,0x9129,0xa14a,0xb16b,0xc18c,0xd1ad,0xe1ce,0xf1ef,
@@ -79,6 +85,14 @@ static const uint16_t crc16tab[256]= {
     0x6e17,0x7e36,0x4e55,0x5e74,0x2e93,0x3eb2,0x0ed1,0x1ef0
 };
 
+/**
+ * @brief 计算输入数据的 CRC16 值
+ *
+ * @param[in] buf       指向输入数据的缓冲区
+ * @param[in] len       输入数据的长度（字节数）
+ * 
+ * @return 返回计算得到的 16 位 CRC 值
+ */
 uint16_t crc16(const char *buf, int len) {
     int counter;
     uint16_t crc = 0;

--- a/src/crc16_slottable.h
+++ b/src/crc16_slottable.h
@@ -8,6 +8,10 @@
  * to make redis cluster route a request to the shard holding this slot 
  */
 
+/* 提供一种 ​CRC16 到 Redis 集群槽位（slot）的映射关系。
+* Redis 集群使用 CRC16 算法对键进行哈希计算，将键分配到 16384 个槽位（slot）中。
+* 此处定义了一个查找表，用于快速确定某个 CRC16 值对应的槽位
+*/
 const char *crc16_slot_table[] = {
 "06S", "Qi", "5L5", "4Iu", "4gY", "460", "1Y7", "1LV", "0QG", "ru", "7Ok", "4ji", "4DE", "65n", "2JH", "I8", "F9", "SX", "7nF", "4KD", 
 "4eh", "6PK", "2ke", "1Ng", "0Sv", "4L", "491", "4hX", "4Ft", "5C4", "2Hy", "09R", "021", "0cX", "4Xv", "6mU", "6Cy", "42R", "0Mt", "nF", 

--- a/src/crc64.c
+++ b/src/crc64.c
@@ -26,11 +26,13 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE. */
 
+/* 该文件实现了一个 ​CRC64 校验算法，用于计算数据的 64 位循环冗余校验码（CRC） */
+ 
 #include "crc64.h"
 #include "crcspeed.h"
-static uint64_t crc64_table[8][256] = {{0}};
+static uint64_t crc64_table[8][256] = {{0}};                    // CRC 表，用于加速计算
 
-#define POLY UINT64_C(0xad93d23594c935a9)
+#define POLY UINT64_C(0xad93d23594c935a9)                       // CRC64 多项式
 /******************** BEGIN GENERATED PYCRC FUNCTIONS ********************/
 /**
  * Generated on Sun Dec 21 14:14:07 2014,
@@ -66,12 +68,20 @@ static uint64_t crc64_table[8][256] = {{0}};
  * \param data_len     The width of \a data expressed in number of bits.
  * \return             The reflected data.
  *****************************************************************************/
+/**
+ * @brief 位反射函数：将数据的位顺序反转
+ *
+ * @param[in] data              需要反转位顺序的数据
+ * @param[in] data_len          数据的位长度
+ *
+ * @return 返回反转位顺序后的数据
+ */
 static inline uint_fast64_t crc_reflect(uint_fast64_t data, size_t data_len) {
-    uint_fast64_t ret = data & 0x01;
+    uint_fast64_t ret = data & 0x01;                            // 取最低位
 
     for (size_t i = 1; i < data_len; i++) {
         data >>= 1;
-        ret = (ret << 1) | (data & 0x01);
+        ret = (ret << 1) | (data & 0x01);                       // 左移并拼接下一位
     }
 
     return ret;
@@ -85,41 +95,63 @@ static inline uint_fast64_t crc_reflect(uint_fast64_t data, size_t data_len) {
  * \param data_len Number of bytes in the \a data buffer.
  * \return         The updated crc value.
  ******************************************************************************/
+/**
+ * @brief CRC64 更新函数：根据输入数据更新 CRC 值
+ *
+ * @param[in] crc               当前的 CRC 值
+ * @param[in] in_data           指向输入数据的缓冲区
+ * @param[in] len               输入数据的字节长度
+ *
+ * @return 返回更新后的 CRC 值
+ */
 uint64_t _crc64(uint_fast64_t crc, const void *in_data, const uint64_t len) {
-    const uint8_t *data = in_data;
-    unsigned long long bit;
+    const uint8_t *data = in_data;                              // 输入数据指针
+    unsigned long long bit;                                     // 临时变量，用于存储当前位
 
-    for (uint64_t offset = 0; offset < len; offset++) {
-        uint8_t c = data[offset];
-        for (uint_fast8_t i = 0x01; i & 0xff; i <<= 1) {
-            bit = crc & 0x8000000000000000;
-            if (c & i) {
-                bit = !bit;
+    for (uint64_t offset = 0; offset < len; offset++) {         // 遍历每个字节
+        uint8_t c = data[offset];                               // 当前字节
+        for (uint_fast8_t i = 0x01; i & 0xff; i <<= 1) {        // 遍历每个位
+            bit = crc & 0x8000000000000000;                     // 取 CRC 的最高位
+            if (c & i) {                                        // 如果当前位为 1
+                bit = !bit;                                     // 反转最高位
             }
 
-            crc <<= 1;
-            if (bit) {
-                crc ^= POLY;
+            crc <<= 1;                                          // 左移 CRC
+            if (bit) {                                          // 如果最高位为 1
+                crc ^= POLY;                                    // 异或多项式
             }
         }
 
-        crc &= 0xffffffffffffffff;
+        crc &= 0xffffffffffffffff;                              // 确保 CRC 为 64 位
     }
 
-    crc = crc & 0xffffffffffffffff;
-    return crc_reflect(crc, 64) ^ 0x0000000000000000;
+    crc = crc & 0xffffffffffffffff;                             // 再次确保 CRC 为 64 位
+    return crc_reflect(crc, 64) ^ 0x0000000000000000;           // 返回最终 CRC 值
 }
 
 /******************** END GENERATED PYCRC FUNCTIONS ********************/
 
 /* Initializes the 16KB lookup tables. */
+/**
+ * @brief CRC64 表初始化函数：初始化 CRC 查找表，用于加速 CRC 计算
+ *
+ */
 void crc64_init(void) {
-    crcspeed64native_init(_crc64, crc64_table);
+    crcspeed64native_init(_crc64, crc64_table);                 // 调用 crcspeed64native_init 函数，填充 crc64_table
 }
 
 /* Compute crc64 */
+/**
+ * @brief CRC64 计算函数：计算输入数据的 CRC64 值
+ *
+ * @param[in] crc               初始的 CRC 值
+ * @param[in] s                 指向输入数据的缓冲区
+ * @param[in] l                 输入数据的字节长度
+ *
+ * @return 返回计算后的 CRC 值
+ */
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l) {
-    return crcspeed64native(crc64_table, crc, (void *) s, l);
+    return crcspeed64native(crc64_table, crc, (void *) s, l);   // 调用 crcspeed64native 函数，使用预计算的 CRC 表加速计算
 }
 
 /* Test main */

--- a/src/crc64.h
+++ b/src/crc64.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 /* CRC64 表初始化函数 */
+/* 应在程序初始化时调用（一次即可） */
 void crc64_init(void);
 /* CRC64 计算函数 */
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);

--- a/src/crc64.h
+++ b/src/crc64.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 
+/* CRC64 表初始化函数 */
 void crc64_init(void);
+/* CRC64 计算函数 */
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
 
 #ifdef REDIS_TEST

--- a/src/crcspeed.c
+++ b/src/crcspeed.c
@@ -27,50 +27,86 @@
   madler@alumni.caltech.edu
  */
 
+ /* 该文件实现了 ​CRC（循环冗余校验）​ 的加速计算功能，通过预计算 CRC 查找表
+ * 利用 ​Slice-by-8 技术（每次处理 8 字节）来加速 CRC 计算。
+ * 支持 ​64 位 和 ​16 位 CRC，并针对 ​小端（Little-Endian）​ 和 ​大端（Big-Endian）​ 架构进行了优化
+ */
+
 #include "crcspeed.h"
 
 /* Fill in a CRC constants table. */
+/**
+ * @brief CRC 表初始化函数：初始化 64 位 CRC 查找表，用于小端架构
+ *
+ * @param[in] crcfn             CRC 计算函数，用于生成单字节的 CRC 值
+ * @param[in] table             8 层 256 项的 CRC 查找表
+ *
+ */
 void crcspeed64little_init(crcfn64 crcfn, uint64_t table[8][256]) {
     uint64_t crc;
 
     /* generate CRCs for all single byte sequences */
+    /* 生成所有单字节序列的 CRC 值 */
+    /* 遍历所有可能的单字节值（0-255） */
     for (int n = 0; n < 256; n++) {
-        unsigned char v = n;
-        table[0][n] = crcfn(0, &v, 1);
+        unsigned char v = n;                                // 将当前值转换为单字节
+        table[0][n] = crcfn(0, &v, 1);                      // 计算单字节的 CRC 值并存入表的第一层
     }
 
     /* generate nested CRC table for future slice-by-8 lookup */
+    /* 生成嵌套的 CRC 表，用于后续的 Slice-by-8 查找 */
+    /* 遍历所有单字节值，生成嵌套的 CRC 表 */
     for (int n = 0; n < 256; n++) {
-        crc = table[0][n];
+        crc = table[0][n];                                  // 获取表的第一层中的 CRC 值
         for (int k = 1; k < 8; k++) {
+            /* 通过异或和移位操作，生成下一层的 CRC 值 */
             crc = table[0][crc & 0xff] ^ (crc >> 8);
-            table[k][n] = crc;
+            table[k][n] = crc;                              // 将生成的 CRC 值存入表的第 k 层
         }
     }
 }
 
+/**
+ * @brief CRC16 表初始化函数：初始化 16 位 CRC 查找表，用于小端架构
+ *
+ * @param[in] crcfn             CRC 计算函数，用于生成单字节的 CRC 值
+ * @param[in] table             8 层 256 项的 CRC 查找表
+ *
+ */
 void crcspeed16little_init(crcfn16 crcfn, uint16_t table[8][256]) {
     uint16_t crc;
 
     /* generate CRCs for all single byte sequences */
+    /* 生成所有单字节序列的 CRC 值 */
+    /* 遍历所有可能的单字节值（0-255） */
     for (int n = 0; n < 256; n++) {
-        table[0][n] = crcfn(0, &n, 1);
+        table[0][n] = crcfn(0, &n, 1);                      // 计算单字节的 CRC 值并存入表的第一层
     }
 
     /* generate nested CRC table for future slice-by-8 lookup */
+    /* 生成嵌套的 CRC 表，用于后续的 Slice-by-8 查找 */
+    /* 遍历所有单字节值，生成嵌套的 CRC 表 */
     for (int n = 0; n < 256; n++) {
-        crc = table[0][n];
+        crc = table[0][n];                                  // 获取表的第一层中的 CRC 值
         for (int k = 1; k < 8; k++) {
+            /* 通过异或和移位操作，生成下一层的 CRC 值 */
             crc = table[0][(crc >> 8) & 0xff] ^ (crc << 8);
-            table[k][n] = crc;
+            table[k][n] = crc;                              // 将生成的 CRC 值存入表的第 k 层
         }
     }
 }
 
 /* Reverse the bytes in a 64-bit word. */
+/**
+ * @brief 字节反转函数：反转 64 位数据的字节顺序
+ *
+ * @param[in] a                 需要反转的 64 位数据
+ *
+ * @return 返回反转后的 64 位数据
+ */
 static inline uint64_t rev8(uint64_t a) {
 #if defined(__GNUC__) || defined(__clang__)
-    return __builtin_bswap64(a);
+    return __builtin_bswap64(a);                   // 使用编译器内置函数进行 64 位字节反转
 #else
     uint64_t m;
 
@@ -84,8 +120,16 @@ static inline uint64_t rev8(uint64_t a) {
 
 /* This function is called once to initialize the CRC table for use on a
    big-endian architecture. */
+/**
+ * @brief 大端架构 CRC 表初始化函数：初始化 64 位 CRC 查找表，用于大端架构
+ *
+ * @param[in] fn                CRC 计算函数
+ * @param[in] big_table         8 层 256 项的 CRC 查找表
+ *
+ */
 void crcspeed64big_init(crcfn64 fn, uint64_t big_table[8][256]) {
     /* Create the little endian table then reverse all the entries. */
+    /* 先创建小端表，然后反转所有条目 */
     crcspeed64little_init(fn, big_table);
     for (int k = 0; k < 8; k++) {
         for (int n = 0; n < 256; n++) {
@@ -94,8 +138,16 @@ void crcspeed64big_init(crcfn64 fn, uint64_t big_table[8][256]) {
     }
 }
 
+/**
+ * @brief 大端架构 CRC16 表初始化函数：初始化 16 位 CRC 查找表，用于大端架构
+ *
+ * @param[in] fn                CRC 计算函数
+ * @param[in] big_table         8 层 256 项的 CRC 查找表
+ *
+ */
 void crcspeed16big_init(crcfn16 fn, uint16_t big_table[8][256]) {
     /* Create the little endian table then reverse all the entries. */
+    /* 先创建小端表，然后反转所有条目 */
     crcspeed16little_init(fn, big_table);
     for (int k = 0; k < 8; k++) {
         for (int n = 0; n < 256; n++) {
@@ -109,17 +161,29 @@ void crcspeed16big_init(crcfn16 fn, uint16_t big_table[8][256]) {
  * *after* calling.
  * 64 bit crc = process 8 bytes at once;
  */
+/**
+ * @brief CRC 计算函数（小端架构）：在小端架构上计算 64 位 CRC
+ *
+ * @param[in] little_table      小端架构的 CRC 查找表
+ * @param[in] crc               初始的 CRC 值
+ * @param[in] buf               指向输入数据的缓冲区
+ * @param[in] len               输入数据的字节长度
+ *
+ * @return 返回计算后的 CRC 值
+ */
 uint64_t crcspeed64little(uint64_t little_table[8][256], uint64_t crc,
                           void *buf, size_t len) {
     unsigned char *next = buf;
 
     /* process individual bytes until we reach an 8-byte aligned pointer */
+    /* 处理单个字节，直到指针 8 字节对齐 */
     while (len && ((uintptr_t)next & 7) != 0) {
         crc = little_table[0][(crc ^ *next++) & 0xff] ^ (crc >> 8);
         len--;
     }
 
     /* fast middle processing, 8 bytes (aligned!) per loop */
+    /* 快速中间处理，每次处理 8 字节（对齐！） */
     while (len >= 8) {
         crc ^= *(uint64_t *)next;
         crc = little_table[7][crc & 0xff] ^
@@ -135,6 +199,7 @@ uint64_t crcspeed64little(uint64_t little_table[8][256], uint64_t crc,
     }
 
     /* process remaining bytes (can't be larger than 8) */
+    /* 处理剩余字节（不超过 8 字节） */
     while (len) {
         crc = little_table[0][(crc ^ *next++) & 0xff] ^ (crc >> 8);
         len--;
@@ -143,17 +208,29 @@ uint64_t crcspeed64little(uint64_t little_table[8][256], uint64_t crc,
     return crc;
 }
 
+/**
+ * @brief CRC16 计算函数（小端架构）：在小端架构上计算 16 位 CRC
+ *
+ * @param[in] little_table      小端架构的 CRC 查找表
+ * @param[in] crc               初始的 CRC 值
+ * @param[in] buf               指向输入数据的缓冲区
+ * @param[in] len               输入数据的字节长度
+ *
+ * @return 返回计算后的 CRC 值
+ */
 uint16_t crcspeed16little(uint16_t little_table[8][256], uint16_t crc,
                           void *buf, size_t len) {
     unsigned char *next = buf;
 
     /* process individual bytes until we reach an 8-byte aligned pointer */
+    /* 处理未对齐的字节，直到指针 8 字节对齐 */
     while (len && ((uintptr_t)next & 7) != 0) {
         crc = little_table[0][((crc >> 8) ^ *next++) & 0xff] ^ (crc << 8);
         len--;
     }
 
     /* fast middle processing, 8 bytes (aligned!) per loop */
+    /* 快速中间处理，每次处理 8 字节（对齐！） */
     while (len >= 8) {
         uint64_t n = *(uint64_t *)next;
         crc = little_table[7][(n & 0xff) ^ ((crc >> 8) & 0xff)] ^
@@ -169,6 +246,7 @@ uint16_t crcspeed16little(uint16_t little_table[8][256], uint16_t crc,
     }
 
     /* process remaining bytes (can't be larger than 8) */
+    /* 处理剩余字节（不超过 8 字节） */
     while (len) {
         crc = little_table[0][((crc >> 8) ^ *next++) & 0xff] ^ (crc << 8);
         len--;
@@ -180,11 +258,21 @@ uint16_t crcspeed16little(uint16_t little_table[8][256], uint16_t crc,
 /* Calculate a non-inverted CRC eight bytes at a time on a big-endian
  * architecture.
  */
+/**
+ * @brief CRC 计算函数（大端架构）：在大端架构上计算 64 位 CRC
+ *
+ * @param[in] big_table         大端架构的 CRC 查找表
+ * @param[in] crc               初始的 CRC 值
+ * @param[in] buf               指向输入数据的缓冲区
+ * @param[in] len               输入数据的字节长度
+ *
+ * @return 返回计算后的 CRC 值
+ */
 uint64_t crcspeed64big(uint64_t big_table[8][256], uint64_t crc, void *buf,
                        size_t len) {
     unsigned char *next = buf;
 
-    crc = rev8(crc);
+    crc = rev8(crc);                                        // 反转数据的字节顺序
     while (len && ((uintptr_t)next & 7) != 0) {
         crc = big_table[0][(crc >> 56) ^ *next++] ^ (crc << 8);
         len--;
@@ -213,12 +301,23 @@ uint64_t crcspeed64big(uint64_t big_table[8][256], uint64_t crc, void *buf,
 }
 
 /* WARNING: Completely untested on big endian architecture.  Possibly broken. */
+/* 警告：在大端架构上未经完全测试。可能不能正常使用。 */
+/**
+ * @brief CRC16 计算函数（大端架构）：在大端架构上计算 16 位 CRC
+ *
+ * @param[in] big_table         大端架构的 CRC 查找表
+ * @param[in] crc_in            初始的 CRC 值
+ * @param[in] buf               指向输入数据的缓冲区
+ * @param[in] len               输入数据的字节长度
+ *
+ * @return 返回计算后的 CRC 值
+ */
 uint16_t crcspeed16big(uint16_t big_table[8][256], uint16_t crc_in, void *buf,
                        size_t len) {
     unsigned char *next = buf;
     uint64_t crc = crc_in;
 
-    crc = rev8(crc);
+    crc = rev8(crc);                                        // 反转数据的字节顺序
     while (len && ((uintptr_t)next & 7) != 0) {
         crc = big_table[0][((crc >> (56 - 8)) ^ *next++) & 0xff] ^ (crc >> 8);
         len--;
@@ -250,23 +349,44 @@ uint16_t crcspeed16big(uint16_t big_table[8][256], uint16_t crc_in, void *buf,
    at a time using passed-in lookup table.
    This selects one of two routines depending on the endianness of
    the architecture. */
+/**
+ * @brief 自动选择架构的 CRC 计算函数：根据当前架构自动选择小端或大端的 CRC 计算函数
+ *
+ * @param[in] table             CRC 查找表
+ * @param[in] crc               初始的 CRC 值
+ * @param[in] buf               指向输入数据的缓冲区
+ * @param[in] len               输入数据的字节长度
+ *
+ * @return 返回计算后的 CRC 值
+ */
 uint64_t crcspeed64native(uint64_t table[8][256], uint64_t crc, void *buf,
                           size_t len) {
     uint64_t n = 1;
-
+    /* 通过检查 n = 1 的字节顺序，判断当前架构是小端还是大端 */
     return *(char *)&n ? crcspeed64little(table, crc, buf, len)
                        : crcspeed64big(table, crc, buf, len);
 }
 
+/**
+ * @brief 自动选择架构的 CRC16 计算函数：根据当前架构自动选择小端或大端的 CRC16 计算函数
+ *
+ * @param[in] table             CRC 查找表
+ * @param[in] crc               初始的 CRC 值
+ * @param[in] buf               指向输入数据的缓冲区
+ * @param[in] len               输入数据的字节长度
+ *
+ * @return 返回计算后的 CRC 值
+ */
 uint16_t crcspeed16native(uint16_t table[8][256], uint16_t crc, void *buf,
                           size_t len) {
     uint64_t n = 1;
-
+    /* 通过检查 n = 1 的字节顺序，判断当前架构是小端还是大端 */
     return *(char *)&n ? crcspeed16little(table, crc, buf, len)
                        : crcspeed16big(table, crc, buf, len);
 }
 
 /* Initialize CRC lookup table in architecture-dependent manner. */
+/* 自动选择架构的 CRC 表初始化函数 */
 void crcspeed64native_init(crcfn64 fn, uint64_t table[8][256]) {
     uint64_t n = 1;
 
@@ -274,6 +394,7 @@ void crcspeed64native_init(crcfn64 fn, uint64_t table[8][256]) {
                 : crcspeed64big_init(fn, table);
 }
 
+/* 自动选择架构的 CRC16 表初始化函数 */
 void crcspeed16native_init(crcfn16 fn, uint16_t table[8][256]) {
     uint64_t n = 1;
 

--- a/src/crcspeed.h
+++ b/src/crcspeed.h
@@ -35,26 +35,38 @@ typedef uint64_t (*crcfn64)(uint64_t, const void *, const uint64_t);
 typedef uint16_t (*crcfn16)(uint16_t, const void *, const uint64_t);
 
 /* CRC-64 */
+/* CRC 表初始化函数：初始化 64 位 CRC 查找表，用于小端架构 */
 void crcspeed64little_init(crcfn64 fn, uint64_t table[8][256]);
+/* 大端架构 CRC 表初始化函数：初始化 64 位 CRC 查找表，用于大端架构 */
 void crcspeed64big_init(crcfn64 fn, uint64_t table[8][256]);
+/* 自动选择架构的 CRC 表初始化函数 */
 void crcspeed64native_init(crcfn64 fn, uint64_t table[8][256]);
 
+/* CRC 计算函数（小端架构）：在小端架构上计算 64 位 CRC */
 uint64_t crcspeed64little(uint64_t table[8][256], uint64_t crc, void *buf,
                           size_t len);
+/* CRC 计算函数（大端架构）：在大端架构上计算 64 位 CRC */
 uint64_t crcspeed64big(uint64_t table[8][256], uint64_t crc, void *buf,
                        size_t len);
+/* 自动选择架构的 CRC 计算函数：根据当前架构自动选择小端或大端的 CRC 计算函数 */
 uint64_t crcspeed64native(uint64_t table[8][256], uint64_t crc, void *buf,
                           size_t len);
 
 /* CRC-16 */
+/* CRC16 表初始化函数：初始化 16 位 CRC 查找表，用于小端架构 */
 void crcspeed16little_init(crcfn16 fn, uint16_t table[8][256]);
+/* 大端架构 CRC16 表初始化函数：初始化 16 位 CRC 查找表，用于大端架构 */
 void crcspeed16big_init(crcfn16 fn, uint16_t table[8][256]);
+/* 自动选择架构的 CRC16 表初始化函数 */
 void crcspeed16native_init(crcfn16 fn, uint16_t table[8][256]);
 
+/* CRC16 计算函数（小端架构）：在小端架构上计算 16 位 CRC */
 uint16_t crcspeed16little(uint16_t table[8][256], uint16_t crc, void *buf,
                           size_t len);
+/* CRC16 计算函数（大端架构）：在大端架构上计算 16 位 CRC */
 uint16_t crcspeed16big(uint16_t table[8][256], uint16_t crc, void *buf,
                        size_t len);
+/* 自动选择架构的 CRC16 计算函数：根据当前架构自动选择小端或大端的 CRC16 计算函数 */
 uint16_t crcspeed16native(uint16_t table[8][256], uint16_t crc, void *buf,
                           size_t len);
 #endif

--- a/src/crcspeed.h
+++ b/src/crcspeed.h
@@ -28,9 +28,15 @@
 #ifndef CRCSPEED_H
 #define CRCSPEED_H
 
+/* 本文件中crc16计算相关未在项目中使用(使用crc16.c中的实现)
+* 主要是基于 ​Slice-by-8 技术 优化的算法用于crc64的计算
+* 题外：迭代历史可查看 https://matt.sh/redis-crcspeed
+*/
+
 #include <inttypes.h>
 #include <stdio.h>
 
+/* 类型声明，内部使用均为crc64文件中的_crc64函数，使用此方法均需调用crc64_init初始化table */
 typedef uint64_t (*crcfn64)(uint64_t, const void *, const uint64_t);
 typedef uint16_t (*crcfn16)(uint16_t, const void *, const uint64_t);
 

--- a/src/localtime.c
+++ b/src/localtime.c
@@ -49,6 +49,8 @@
  * Note that this function does not work for dates < 1/1/1970, it is solely
  * designed to work with what time(NULL) may return, and to support Redis
  * logging of the dates, it's not really a complete implementation. */
+
+/* 判断是否为闰年 */
 static int is_leap_year(time_t year) {
     if (year % 4) return 0;         /* A year not divisible by 4 is not leap. */
     else if (year % 100) return 1;  /* If div by 4 and not 100 is surely leap. */
@@ -56,51 +58,59 @@ static int is_leap_year(time_t year) {
     else return 1;                  /* If div by 100 and 400 is leap. */
 }
 
+/* 功能：将时间戳 t 转换为本地时间，存储到 tm 结构体 tmp
+* 参数：
+*   tmp   - 输出时间结构体
+*   t     - 时间戳（自1970-01-01 UTC的秒数）
+*   tz    - 时区偏移秒数（东区为正）
+*   dst   - 夏令时标志（0=未生效，1=生效） 
+* 补充说明：此函数是 Redis 5.0.0 引入的无锁本地时间转换工具，用于替代 localtime_r，​避免多线程或 fork 场景下的死锁风险
+*/
 void nolocks_localtime(struct tm *tmp, time_t t, time_t tz, int dst) {
+    /* 定义时间单位常量（秒） */
     const time_t secs_min = 60;
     const time_t secs_hour = 3600;
-    const time_t secs_day = 3600*24;
+    const time_t secs_day = 3600 * 24;
 
-    t -= tz;                            /* Adjust for timezone. */
-    t += 3600*dst;                      /* Adjust for daylight time. */
-    time_t days = t / secs_day;         /* Days passed since epoch. */
-    time_t seconds = t % secs_day;      /* Remaining seconds. */
+    /* 调整时区和夏令时 */
+    t -= tz;                                        // 减去时区偏移（如东八区 -28800 秒）
+    t += 3600 * dst;                                // 增加夏令时带来的1小时偏移（若生效）
 
-    tmp->tm_isdst = dst;
-    tmp->tm_hour = seconds / secs_hour;
-    tmp->tm_min = (seconds % secs_hour) / secs_min;
-    tmp->tm_sec = (seconds % secs_hour) % secs_min;
+    /* 计算自纪元以来的天数和剩余秒数 */
+    time_t days = t / secs_day;                     // 总天数
+    time_t seconds = t % secs_day;                  // 当天剩余秒数
 
-    /* 1/1/1970 was a Thursday, that is, day 4 from the POV of the tm structure
-     * where sunday = 0, so to calculate the day of the week we have to add 4
-     * and take the modulo by 7. */
-    tmp->tm_wday = (days+4)%7;
+    /* 填充基本时间字段 */
+    tmp->tm_isdst = dst;                            // 夏令时标志
+    tmp->tm_hour = seconds / secs_hour;             // 小时（0-23）
+    tmp->tm_min = (seconds % secs_hour) / secs_min; // 分钟（0-59）
+    tmp->tm_sec = (seconds % secs_hour) % secs_min; // 秒（0-59）
 
-    /* Calculate the current year. */
-    tmp->tm_year = 1970;
-    while(1) {
-        /* Leap years have one day more. */
-        time_t days_this_year = 365 + is_leap_year(tmp->tm_year);
-        if (days_this_year > days) break;
-        days -= days_this_year;
-        tmp->tm_year++;
+    /* 计算星期几（1970-01-01 是星期四，故 days+4 后模7） */
+    tmp->tm_wday = (days + 4) % 7;                  // 0=周日，1=周一，... 6=周六
+
+    /* 计算年份 */
+    tmp->tm_year = 1970;                            // 起始年份
+    while (1) {
+        time_t days_this_year = 365 + is_leap_year(tmp->tm_year); // 闰年判断
+        if (days_this_year > days) break;           // 剩余天数不足一年则退出
+        days -= days_this_year;                     // 减去当前年份天数
+        tmp->tm_year++;                             // 年份递增
     }
-    tmp->tm_yday = days;  /* Number of day of the current year. */
+    tmp->tm_yday = days;                            // 一年中的第几天（0-365）
 
-    /* We need to calculate in which month and day of the month we are. To do
-     * so we need to skip days according to how many days there are in each
-     * month, and adjust for the leap year that has one more day in February. */
+    /* 计算月份和日期 */
     int mdays[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-    mdays[1] += is_leap_year(tmp->tm_year);
+    mdays[1] += is_leap_year(tmp->tm_year);         // 闰年2月加1天
 
-    tmp->tm_mon = 0;
-    while(days >= mdays[tmp->tm_mon]) {
+    tmp->tm_mon = 0;                                // 月份从0（1月）开始
+    while (days >= mdays[tmp->tm_mon]) {
         days -= mdays[tmp->tm_mon];
-        tmp->tm_mon++;
+        tmp->tm_mon++;                              // 递增月份直至剩余天数不足一个月
     }
 
-    tmp->tm_mday = days+1;  /* Add 1 since our 'days' is zero-based. */
-    tmp->tm_year -= 1900;   /* Surprisingly tm_year is year-1900. */
+    tmp->tm_mday = days + 1;                        // 日期从1开始（days为0-based）
+    tmp->tm_year -= 1900;                           // tm_year存储年份-1900（兼容标准tm结构）
 }
 
 #ifdef LOCALTIME_TEST_MAIN

--- a/src/mt19937-64.c
+++ b/src/mt19937-64.c
@@ -53,114 +53,146 @@
    email: m-mat @ math.sci.hiroshima-u.ac.jp (remove spaces)
 */
 
+/* 模块功能： ​64 位梅森旋转算法（Mersenne Twister）​ 的标准实现，用于生成高质量伪随机数 */
 
 #include "mt19937-64.h"
 #include <stdio.h>
 
-#define NN 312
-#define MM 156
-#define MATRIX_A 0xB5026F5AA96619E9ULL
-#define UM 0xFFFFFFFF80000000ULL /* Most significant 33 bits */
-#define LM 0x7FFFFFFFULL /* Least significant 31 bits */
+#define NN 312                          // 状态数组长度（梅森素数周期参数）
+#define MM 156                          // 旋转偏移量（算法核心参数）
+#define MATRIX_A 0xB5026F5AA96619E9ULL  // 旋转矩阵常数
+#define UM 0xFFFFFFFF80000000ULL        // 高位掩码（保留最高33位）
+#define LM 0x7FFFFFFFULL                // 低位掩码（保留最低31位）
 
 
 /* The array for the state vector */
-static unsigned long long mt[NN];
+static unsigned long long mt[NN];       // 状态数组，用于存储随机数生成器的状态
 /* mti==NN+1 means mt[NN] is not initialized */
-static int mti=NN+1;
+static int mti=NN+1;                    // 当前状态数组的索引，mti==NN+1 表示未初始化
 
 /* initializes mt[NN] with a seed */
+/* ​单种子初始化函数
+* 操作逻辑：用种子生成初始状态数组，采用 ​线性同余混合算法 确保随机性
+*/
 void init_genrand64(unsigned long long seed)
 {
-    mt[0] = seed;
-    for (mti=1; mti<NN; mti++)
+    mt[0] = seed;                       // 使用种子初始化状态数组的第一个元素
+    for (mti=1; mti<NN; mti++)          // 递推填充状态数组
         mt[mti] =  (6364136223846793005ULL * (mt[mti-1] ^ (mt[mti-1] >> 62)) + mti);
 }
 
 /* initialize by an array with array-length */
 /* init_key is the array for initializing keys */
 /* key_length is its length */
+/* ​多种子数组初始化函数
+* 操作逻辑：首先使用基准种子初始化，然后通过非线性混合算法将多个种子混合到状态数组中
+*/
 void init_by_array64(unsigned long long init_key[],
                      unsigned long long key_length)
 {
     unsigned long long i, j, k;
-    init_genrand64(19650218ULL);
+    init_genrand64(19650218ULL);              // 使用基准种子初始化状态数组
     i=1; j=0;
-    k = (NN>key_length ? NN : key_length);
-    for (; k; k--) {
-        mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 62)) * 3935559000370003845ULL))
-          + init_key[j] + j; /* non linear */
+    k = (NN>key_length ? NN : key_length);    // 选择较大的值作为循环次数
+    for (; k; k--) {                          // 确保状态数组和种子数组都被充分处理
+        /* 非线性混合算法：将种子数组 init_key 混合到状态数组 mt 中 */
+        mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 62)) * 3935559000370003845ULL))  // （位运算）提取前一个状态值的高位信息，增加混合性
+          + init_key[j] + j; /* non linear */ // 加法运算，将种子数组的值和索引值混合到状态数组中
         i++; j++;
-        if (i>=NN) { mt[0] = mt[NN-1]; i=1; }
-        if (j>=key_length) j=0;
+        if (i>=NN) { mt[0] = mt[NN-1]; i=1; } // 循环回状态数组开头
+        if (j>=key_length) j=0;               // 循环回种子数组开头
     }
-    for (k=NN-1; k; k--) {
+    for (k=NN-1; k; k--) {                    // 处理状态数组的每个元素
+        /* 进一步非线性混合：增强状态数组的随机性 */
         mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 62)) * 2862933555777941757ULL))
-          - i; /* non linear */
+          - i; /* non linear */               // 此处引入索引值，增加差异性
         i++;
-        if (i>=NN) { mt[0] = mt[NN-1]; i=1; }
+        if (i>=NN) { mt[0] = mt[NN-1]; i=1; } // 循环回状态数组开头
     }
 
+    /* 确保状态数组的最高位为 1，避免全零状态 */
     mt[0] = 1ULL << 63; /* MSB is 1; assuring non-zero initial array */
 }
 
 /* generates a random number on [0, 2^64-1]-interval */
+/* 生成 64 位随机数函数
+* 操作逻辑：该函数生成一个 64 位的随机数。首先检查状态数组是否需要更新，
+* 然后通过旋转操作生成新的状态数组。最后对状态数组中的元素进行一系列位操作，生成最终的随机数
+*/
 unsigned long long genrand64_int64(void)
 {
     int i;
     unsigned long long x;
-    static unsigned long long mag01[2]={0ULL, MATRIX_A};
+    static unsigned long long mag01[2]={0ULL, MATRIX_A};  // mag01 数组，用于旋转操作
 
-    if (mti >= NN) { /* generate NN words at one time */
+    if (mti >= NN) { /* generate NN words at one time */  // 如果状态数组已用完，重新生成
 
         /* if init_genrand64() has not been called, */
         /* a default initial seed is used     */
         if (mti == NN+1)
-            init_genrand64(5489ULL);
+            init_genrand64(5489ULL);                      // 如果未初始化，使用默认种子初始化
 
+        /* 对状态数组进行旋转操作，生成新的状态值 */
         for (i=0;i<NN-MM;i++) {
+            /* 提取状态数组 mt[i] 的高 33 位和 mt[i + 1] 的低 31 位，组合成一个新的值 x */
             x = (mt[i]&UM)|(mt[i+1]&LM);
+            /* 对 x 进行右移 1 位操作，并根据 x 的最低位决定是否与 MATRIX_A 进行异或操作，生成新的状态值 */
             mt[i] = mt[i+MM] ^ (x>>1) ^ mag01[(int)(x&1ULL)];
         }
+        /* 与第一个 for 循环类似，但使用不同的偏移量 MM - NN，确保状态数组的连续性 */
         for (;i<NN-1;i++) {
             x = (mt[i]&UM)|(mt[i+1]&LM);
             mt[i] = mt[i+(MM-NN)] ^ (x>>1) ^ mag01[(int)(x&1ULL)];
         }
+        /* 对状态数组的最后一个元素进行旋转操作，确保状态数组的完整性 */
         x = (mt[NN-1]&UM)|(mt[0]&LM);
         mt[NN-1] = mt[MM-1] ^ (x>>1) ^ mag01[(int)(x&1ULL)];
 
-        mti = 0;
+        mti = 0;                                          // 重置索引
     }
 
-    x = mt[mti++];
+    x = mt[mti++];                                        // 提取当前状态值
+    /* 随机数生成公式，对状态值进行位操作，生成最终的随机数 */
+    x ^= (x >> 29) & 0x5555555555555555ULL;               // 用于提取和混合奇数位信息
+    x ^= (x << 17) & 0x71D67FFFEDA60000ULL;               // 提取和混合特定位置的位信息
+    x ^= (x << 37) & 0xFFF7EEE000000000ULL;               // 提取和混合特定位置的位信息
+    x ^= (x >> 43);                                       // 进一步混合
 
-    x ^= (x >> 29) & 0x5555555555555555ULL;
-    x ^= (x << 17) & 0x71D67FFFEDA60000ULL;
-    x ^= (x << 37) & 0xFFF7EEE000000000ULL;
-    x ^= (x >> 43);
-
+    /* 返回生成的 64 位随机数 */
     return x;
 }
 
 /* generates a random number on [0, 2^63-1]-interval */
+/* 生成 63 位随机数函数
+* 操作逻辑：该函数生成一个 63 位的随机数，通过将 64 位随机数右移一位得到
+*/
 long long genrand64_int63(void)
 {
     return (long long)(genrand64_int64() >> 1);
 }
 
 /* generates a random number on [0,1]-real-interval */
+/* 生成 [0,1) 区间内的随机数函数
+* 操作逻辑：通过将 64 位随机数右移 11 位并乘以一个常数得到
+*/
 double genrand64_real1(void)
 {
     return (genrand64_int64() >> 11) * (1.0/9007199254740991.0);
 }
 
 /* generates a random number on [0,1)-real-interval */
+/* 生成 [0,1) 区间内的随机数函数
+* 操作逻辑：通过将 64 位随机数右移 11 位并乘以一个常数得到
+*/
 double genrand64_real2(void)
 {
     return (genrand64_int64() >> 11) * (1.0/9007199254740992.0);
 }
 
 /* generates a random number on (0,1)-real-interval */
+/* 生成 (0,1) 区间内的随机数函数
+* 操作逻辑：通过将 64 位随机数右移 12 位并加上 0.5，再乘以一个常数得到
+*/
 double genrand64_real3(void)
 {
     return ((genrand64_int64() >> 12) + 0.5) * (1.0/4503599627370496.0);

--- a/src/mt19937-64.h
+++ b/src/mt19937-64.h
@@ -57,31 +57,39 @@
 #define __MT19937_64_H
 
 /* initializes mt[NN] with a seed */
+/* 单种子初始化函数 */
 void init_genrand64(unsigned long long seed);
 
 /* initialize by an array with array-length */
 /* init_key is the array for initializing keys */
 /* key_length is its length */
+/* 多种子数组初始化函数 */
 void init_by_array64(unsigned long long init_key[],
                      unsigned long long key_length);
 
 /* generates a random number on [0, 2^64-1]-interval */
+/* 生成 64 位随机数函数 */
 unsigned long long genrand64_int64(void);
 
 
 /* generates a random number on [0, 2^63-1]-interval */
+/* 生成 63 位随机数函数 */
 long long genrand64_int63(void);
 
 /* generates a random number on [0,1]-real-interval */
+/* 生成 [0,1] 区间内的随机数函数 */
 double genrand64_real1(void);
 
 /* generates a random number on [0,1)-real-interval */
+/* 生成 [0,1) 区间内的随机数函数 */
 double genrand64_real2(void);
 
 /* generates a random number on (0,1)-real-interval */
+/* 生成 (0,1) 区间内的随机数函数 */
 double genrand64_real3(void);
 
 /* generates a random number on (0,1]-real-interval */
+/* 生成 (0,1] 区间内的随机数函数 （未定义） */
 double genrand64_real4(void);
 
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -6897,7 +6897,7 @@ int main(int argc, char **argv) {
     srand(time(NULL)^getpid()^tv.tv_usec);
     srandom(time(NULL)^getpid()^tv.tv_usec);
     init_genrand64(((long long) tv.tv_sec * 1000000 + tv.tv_usec) ^ getpid());
-    crc64_init();
+    crc64_init();                           // 重要，使用crc64必须前置初始化填充crc64表，后续才能计算得值
 
     /* Store umask value. Because umask(2) only offers a set-and-get API we have
      * to reset it and restore it back. We do this early to avoid a potential


### PR DESCRIPTION
localtime.c 主要用于实现一个无锁的本地时间转换函数
mt19937-64.c ​主要通过64位梅森旋转算法生成高质量伪随机数